### PR TITLE
Fix Arbitary Code Execution using shell-escape

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "email": "franciscojsucreg@gmail.com",
     "url": "https://github.com/franciscosucre"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@types/shell-escape": "^0.2.0",
+    "shell-escape": "^0.2.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/franciscosucre/sugo-wkhtmltopdf.git"

--- a/src/wkhtmltopdf.ts
+++ b/src/wkhtmltopdf.ts
@@ -13,7 +13,7 @@ const quote = (val: string) => {
 export const wkhtmltopdf = (input: string, options: string[] = []) =>
   new Promise<Buffer>((resolve, reject) => {
     const isUrl = /^(https?|file):\/\//.test(input);
-    const childArgs = [wkhtmltopdf.command].concat(options, [isUrl ? quote(input) : '-', '-']);
+    const childArgs = [wkhtmltopdf.command].concat(options, [isUrl ? input : '-', '-']);
     let child: ChildProcess;
     if (process.platform === 'win32') {
       child = spawn(wkhtmltopdf.command, childArgs.slice(1));

--- a/src/wkhtmltopdf.ts
+++ b/src/wkhtmltopdf.ts
@@ -1,4 +1,5 @@
 import { ChildProcess, spawn } from 'child_process';
+import * as shellescape from 'shell-escape';
 
 const quote = (val: string) => {
   // escape and quote the value if it is a string and this isn't windows
@@ -17,9 +18,9 @@ export const wkhtmltopdf = (input: string, options: string[] = []) =>
     if (process.platform === 'win32') {
       child = spawn(wkhtmltopdf.command, childArgs.slice(1));
     } else if (process.platform === 'darwin') {
-      child = spawn('/bin/sh', ['-c', childArgs.join(' ') + ' | cat ; exit ${PIPESTATUS[0]}']);
+      child = spawn('/bin/sh', ['-c', shellescape(childArgs) + ' | cat ; exit ${PIPESTATUS[0]}']);
     } else {
-      child = spawn(wkhtmltopdf.shell, ['-c', childArgs.join(' ') + ' | cat ; exit ${PIPESTATUS[0]}']);
+      child = spawn(wkhtmltopdf.shell, ['-c', shellescape(childArgs) + ' | cat ; exit ${PIPESTATUS[0]}']);
     }
     child.on('exit', (code: number) => {
       if (code !== 0) {


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-%40sugo%2Fwkhtmltopdf

### ⚙️ Description *

wkhtmltopdf was vulnerable against arbitrary command injection cause some user supplied inputs were taken and composed into string to be executed without prior sanitization
After update Arbitary Code Execution is avoided

### 💻 Technical Description *

Commands that relay on piping functions are excuted usng spawn and piping, shell-escape was used to sanitize params for execution on non windows systems.

### 🐛 Proof of Concept (PoC) *

1. Create the following PoC file:

```js
// poc.js
var wkp = require("@sugo/wkhtmltopdf")
wkp.wkhtmltopdf("test", [';touch', 'HACKED']);
```
2. Check there aren't files called `HACKED` 
3. Execute the following commands in another terminal:

```bash
npm i @sugo/wkhtmltopdf # Install affected module
node poc.js #  Run the PoC
```
4. Recheck the files: now `HACKED` has been created

![Captura de pantalla de 2020-09-09 15-13-05](https://user-images.githubusercontent.com/7505980/92604312-0ed60500-f2b9-11ea-971e-bddcf58888df.png)


### 🔥 Proof of Fix (PoF) *

After fix no file is created

![Captura de pantalla de 2020-09-09 16-17-55](https://user-images.githubusercontent.com/7505980/92604324-11d0f580-f2b9-11ea-8f88-a19f39d7dcd0.png)

### 👍 User Acceptance Testing (UAT)

Commands can be executed normally, functionality unafected
![Captura de pantalla de 2020-09-09 16-23-42](https://user-images.githubusercontent.com/7505980/92604333-1695a980-f2b9-11ea-9a8e-09e4104452f5.png)
pdf created with util